### PR TITLE
docs: Add attestation station docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ This is a [Optimism](https://github.com/ethereum-optimism) + [wagmi](https://wag
 
 # Who is this for
 
+This starter is a great choice for any of the following groups:
+
 - Hackers hacking on [optimism](https://www.optimism.io/)
 - Hackers hacking on the [attestation station](https://community.optimism.io/docs/governance/attestation-station/)
 - Hackers interested in using [the most modern and robust web3 full stack development stack](https://twitter.com/gakonst/status/1630038261941796866)
@@ -35,7 +37,7 @@ These instructions were verified with Node 18.
 
 ### Install Foundry
 
-You will need to install [Foundry](https://book.getfoundry.sh/getting-started/installation) to build your smart contracts. 
+You will need to install [Foundry](https://book.getfoundry.sh/getting-started/installation) to build your smart contracts.
 
 1. Run the following command:
 
@@ -47,7 +49,6 @@ You will need to install [Foundry](https://book.getfoundry.sh/getting-started/in
 
 1. Run `foundryup`.
 
-
 </details>
 
 ## Start the application
@@ -57,7 +58,7 @@ You will need to install [Foundry](https://book.getfoundry.sh/getting-started/in
    ```sh
    git clone https://github.com/ethereum-optimism/optimism-starter.git
    ```
-    
+
 1. Install the necessary node packages:
 
    ```sh
@@ -66,9 +67,11 @@ You will need to install [Foundry](https://book.getfoundry.sh/getting-started/in
    ```
 
 1. Start the frontend with `npm run dev`
+
    ```sh
    npm run dev
    ```
+
    If you get errors during this step, you might need to [update your Foundry to the latest version](#install-foundry).
 
 1. Open [localhost:5173](http://localhost:5173) in your browser.
@@ -106,7 +109,6 @@ You can read a more in-depth guide on using Forge to deploy a smart contract [he
 
 Below are the steps to deploying a smart contract to Ethereum Mainnet using Forge:
 
-
 ## Set up environment
 
 ### Get an Etherscan key
@@ -131,10 +133,9 @@ You will first need to set up your `.env` to tell Forge where to deploy your con
    - `ETHERSCAN_API_KEY`: Your Etherscan API Key.
 
    - `FORGE_RPC_URL`: The RPC URL of the network to which you deploy.
-   If you use [Alchemy](https://github.com/ethereum-optimism/optimism-tutorial/tree/main/ecosystem/alchemy), your URL will look like this: `https://opt-goerli.g.alchemy.com/v2/<Alchemy API Key>`
- 
-   - `FORGE_PRIVATE_KEY`: The private key of the wallet you want to deploy from.
+     If you use [Alchemy](https://github.com/ethereum-optimism/optimism-tutorial/tree/main/ecosystem/alchemy), your URL will look like this: `https://opt-goerli.g.alchemy.com/v2/<Alchemy API Key>`
 
+   - `FORGE_PRIVATE_KEY`: The private key of the wallet you want to deploy from.
 
 ## Deploy contract
 
@@ -178,16 +179,9 @@ Head to [localhost:5173](http://localhost:5173) in your browser, connect your wa
 
 > Tip: If you import an Anvil private key into your browser wallet (MetaMask, Coinbase Wallet, etc) – you will have 10,000 ETH to play with 😎. The private key is found in the terminal under "Private Keys" when you start up an Anvil instance with `npm run dev:foundry`.
 
-# ATST
+# Attestation station
 
-To interact with the attestation station this library uses the minimal [@eth-optimism/atst](https://www.npmjs.com/package/@eth-optimism/atst) package currently in beta as well as it's accompanying cli. Feel free to open up issues for ideas of improvements for atst. We are also happy to give you ideas of how you could build an even better version of ATST or make it better for your hack!
-
-## Attestation station indexers
-
-An API for the attestation station can be used here: [nxyz attestation station](https://docs.n.xyz/reference/attestation-station)
-A graphql api is here: [ponder attestation station](https://attestation-station-api-production.up.railway.app/graphql?query=%7B%0A%20%20attestations(where%3A%20%7B%20creator%3A%20%220x60c5C9c98bcBd0b0F2fD89B24c16e533BaA8CdA3%22%20%7D)%20%7B%0A%20%20%20%20id%0A%20%20%20%20creator%0A%20%20%20%20about%0A%20%20%20%20key%0A%20%20%20%20val%0A%20%20%7D%0A%7D%0A%0A)
-
-Many hackers are building their own as well!
+This starkit comes preloaded with tools for working with the attestation station! To learn more check out [attestation-station.md](/attestation-station.md)
 
 # Alternatives
 

--- a/attestation-station.md
+++ b/attestation-station.md
@@ -1,0 +1,47 @@
+# Attestation Station
+
+This starter comes preloaded with the [attestation station](https://docs.n.xyz/reference/attestation-station)
+
+- [@eth-optimism/atst](https://www.npmjs.com/package/@eth-optimism/atst) sdk
+- Attestation station contract included for convenience
+- Automatically generated react hooks
+
+# Usage
+
+The attestation station is meant to be as simple as possible so you, the community, lead the direction it takes. Every attestation has the following properties:
+
+1. Creator - the address making the attestation
+2. About - An address the attestation is about
+3. Key - A 32 byte key
+4. Val - An arbitrary value in bytes
+
+See the [official documentation](https://docs.n.xyz/reference/attestation-station) for more
+
+# Contracts
+
+The attestation station is deterministically deployed to Optimism and Optimism goerli at `0xEE36eaaD94d1Cc1d0eccaDb55C38bFfB6Be06C77` on both [Optimism](https://optimistic.etherscan.io/address/0xEE36eaaD94d1Cc1d0eccaDb55C38bFfB6Be06C77) and [Optimism Goerli](https://goerli-optimism.etherscan.io/address/0xee36eaad94d1cc1d0eccadb55c38bffb6be06c77)
+
+# ATST SDK
+
+To interact with the attestation station this library uses the minimal [@eth-optimism/atst](https://www.npmjs.com/package/@eth-optimism/atst) package currently in beta as well as it's accompanying cli. Feel free to open up issues for ideas of improvements for atst. We are also happy to give you ideas of how you could build an even better version of ATST or make it better for your hack!
+
+# ATST CLI
+
+For convenience we also include the atst cli. It's a great way to interact with the atst from command line. To get started try reading an attestation
+
+```bash
+npx atst read --key "optimist.base-uri" --about 0x2335022c740d17c2837f9C884Bfe4fFdbf0A95D5 --creator 0x60c5C9c98bcBd0b0F2fD89B24c16e533BaA8CdA3
+```
+
+For more information run the help page
+
+```bash
+npx atst --help
+```
+
+## Attestation station indexers
+
+An API for the attestation station can be used here: [nxyz attestation station](https://docs.n.xyz/reference/attestation-station)
+A graphql api is here: [ponder attestation station](<https://attestation-station-api-production.up.railway.app/graphql?query=%7B%0A%20%20attestations(where%3A%20%7B%20creator%3A%20%220x60c5C9c98bcBd0b0F2fD89B24c16e533BaA8CdA3%22%20%7D)%20%7B%0A%20%20%20%20id%0A%20%20%20%20creator%0A%20%20%20%20about%0A%20%20%20%20key%0A%20%20%20%20val%0A%20%20%7D%0A%7D%0A%0A>)
+
+Many hackers are building their own as well!


### PR DESCRIPTION
We are releasing the attestation station sdk today so move the attestation station docs to it's own md file with more detailed documentation.

Note: the official docs will remain the most detailed source of information