### PR TITLE
Fix Vite building error

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,6 +12,18 @@ export default defineConfig({
   define: {
     global: "globalThis",
   },
+  /**
+   * Fixes the `define` behavior which replaces `global` with `globalThis` where unappropriate
+   * @see https://github.com/wagmi-dev/create-wagmi/pull/73/files
+   */
+  build: {
+    rollupOptions: {
+      external: [
+        "@safe-globalThis/safe-apps-provider",
+        "@safe-globalThis/safe-apps-sdk",
+      ],
+    },
+  },
   resolve: {
     /**
      * Polyfills nodejs imports

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
   /**
    * Fixes the `define` behavior which replaces `global` with `globalThis` where unappropriate
    * @see https://github.com/wagmi-dev/create-wagmi/pull/73/files
+   * @see https://github.com/wagmi-dev/wagmi/issues/2989
    */
   build: {
     rollupOptions: {


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

Fixes a Vite building error:
```
[vite]: Rollup failed to resolve import "@safe-globalThis/safe-apps-provider" from "/home/denis/Workspaces/superhack/optimism-starter/node_modules/@wagmi/connectors/dist/safe.js".
This is most likely unintended because it can break your application at runtime.
If you do want to externalize this module explicitly add it to
`build.rollupOptions.external`
```

**Tests**

Just ensured manually that the Vite build stopped failing after this change was introduced. 

**Additional context**

The Vite config is originated from the `create-wagmi` project, so as [the fix](https://github.com/wagmi-dev/create-wagmi/pull/73).